### PR TITLE
AppBarLayoutCompose: Fix unnecessary recompositions that occur during scrolling.

### DIFF
--- a/AppBarLayoutCompose/app/src/main/java/com/canlioya/appbarlayoutcompose/FlexibleTopBar.kt
+++ b/AppBarLayoutCompose/app/src/main/java/com/canlioya/appbarlayoutcompose/FlexibleTopBar.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.TopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -66,8 +67,12 @@ fun FlexibleTopBar(
     // ensures that the colors will adjust whether the app bar behavior is pinned or scrolled.
     // This may potentially animate or interpolate a transition between the container-color and the
     // container's scrolled-color according to the app bar's scroll state.
-    val colorTransitionFraction = scrollBehavior?.state?.overlappedFraction ?: 0f
-    val fraction = if (colorTransitionFraction > 0.01f) 1f else 0f
+    val fraction by remember(scrollBehavior) {
+        derivedStateOf {
+            val colorTransitionFraction = scrollBehavior?.state?.overlappedFraction ?: 0f
+            if (colorTransitionFraction > 0.01f) 1f else 0f
+        }
+    }
     val appBarContainerColor by animateColorAsState(
         targetValue = colors.containerColor(fraction),
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow)


### PR DESCRIPTION
The previous implementation was accessing the scroll state object directly inside the composable, causing a lot of unnecessary recompositions whenever scroll is happening, making it extremely insufficient. I simply solved the issue by wrapping the access to the scroll state inside derivedStateOf, making recomposition happens only when it's necessary.